### PR TITLE
v-toolbar__content height to be auto

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -88,7 +88,7 @@ export default class DataView extends Vue {
   }
 }
 .v-toolbar__content {
-  height: 80px !important;
+  height: auto !important;
 }
 .v-toolbar__title {
   white-space: inherit !important;


### PR DESCRIPTION
## 📝 関連issue
- close #293

## ⛏ 変更内容
- タイトル部が固定値 80px になっているのを、auto に変更
